### PR TITLE
EnvDashboardView/index.jelly: print the dashboard description above the table

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/environmentdashboard/EnvDashboardView/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/environmentdashboard/EnvDashboardView/index.jelly
@@ -2,7 +2,11 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:f="/lib/form">
     <l:layout>
         <l:main-panel>
-            <p align="right"><a href="configure">Configure</a><st:nbsp/><st:nbsp/><st:nbsp/><a href="delete">Delete</a></p><br /><br />
+            <table width="100%" border="0"><tr>
+                <td>${it.getDescription()}</td>
+                <td align="right"><a href="configure">Configure</a><st:nbsp/><st:nbsp/><st:nbsp/><a href="delete">Delete</a></td>
+            </tr></table>
+            <br /><br />
             <st:include page="main.jelly"/>
             <j:if test="${h.hasPermission(app.ADMINISTER)}">
                 <f:form name="purge" method="post" action="purgeSubmit" tableClass="advancedLink">

--- a/src/main/resources/org/jenkinsci/plugins/environmentdashboard/EnvDashboardView/main.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/environmentdashboard/EnvDashboardView/main.jelly
@@ -246,8 +246,7 @@
                                             <strong>
                                                 <j:if test="${deployment.get('packageName').equals('') || deployment.get('packageName') == null}">${deployment.get('buildNum')}</j:if>
                                                 <j:if test="${!deployment.get('packageName').equals('') &amp;&amp; deployment.get('packageName') != null}">${deployment.get('packageName')}</j:if>
-												&#160;
-                                                <j:switch on="${deployment.get('buildstatus')}">
+                                                &#160;<j:switch on="${deployment.get('buildstatus')}">
 													<j:case value="SUCCESS">
                                                         <span title="SUCCESS" style="color:green;">&#10004;</span>
 													</j:case>

--- a/src/main/resources/org/jenkinsci/plugins/environmentdashboard/EnvDashboardView/main.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/environmentdashboard/EnvDashboardView/main.jelly
@@ -246,7 +246,8 @@
                                             <strong>
                                                 <j:if test="${deployment.get('packageName').equals('') || deployment.get('packageName') == null}">${deployment.get('buildNum')}</j:if>
                                                 <j:if test="${!deployment.get('packageName').equals('') &amp;&amp; deployment.get('packageName') != null}">${deployment.get('packageName')}</j:if>
-												<j:switch on="${deployment.get('buildstatus')}">
+												&#160;
+                                                <j:switch on="${deployment.get('buildstatus')}">
 													<j:case value="SUCCESS">
                                                         <span title="SUCCESS" style="color:green;">&#10004;</span>
 													</j:case>


### PR DESCRIPTION
Also add whitespace between the "packageName" and the icon (failed/successful build).

This PR is mauvais-tons regarding use of HTML tables instead of jelly tags, but this is in a dedicated page (not breaking job config UI fixed by #171) and cleaning up that augeas stable is an effort for another week. So a little more mess seems okay :) 